### PR TITLE
Fixed warnings in headers.

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -210,7 +210,7 @@ class AstVisitor {
     }
 
 #define VISITOR_FUNCTION(type, name) \
-    virtual void visit##type(type* node) {}
+    virtual void visit##type(type* node) { static_cast<void>(node); }
 
     FOR_NODES(VISITOR_FUNCTION)
 #undef VISITOR_FUNCTION
@@ -305,6 +305,7 @@ class StringLiteralNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
+		static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(StringLiteralNode);
@@ -317,11 +318,12 @@ class IntLiteralNode : public AstNode {
     AstNode(index), _intLiteral(intLiteral) {
     }
 
-    const int64_t literal() const {
+    int64_t literal() const {
         return _intLiteral;
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
+		static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(IntLiteralNode);
@@ -339,6 +341,7 @@ class DoubleLiteralNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
+		static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(DoubleLiteralNode);
@@ -356,6 +359,7 @@ class LoadNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
+		static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(LoadNode);
@@ -456,6 +460,7 @@ class NativeCallNode : public AstNode {
 
 
     virtual void visitChildren(AstVisitor* visitor) const {
+		static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(NativeCallNode);

--- a/include/ast.h
+++ b/include/ast.h
@@ -305,7 +305,7 @@ class StringLiteralNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
-		static_cast<void>(visitor);
+        static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(StringLiteralNode);
@@ -323,7 +323,7 @@ class IntLiteralNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
-		static_cast<void>(visitor);
+        static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(IntLiteralNode);
@@ -341,7 +341,7 @@ class DoubleLiteralNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
-		static_cast<void>(visitor);
+        static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(DoubleLiteralNode);
@@ -359,7 +359,7 @@ class LoadNode : public AstNode {
     }
 
     virtual void visitChildren(AstVisitor* visitor) const {
-		static_cast<void>(visitor);
+        static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(LoadNode);
@@ -460,7 +460,7 @@ class NativeCallNode : public AstNode {
 
 
     virtual void visitChildren(AstVisitor* visitor) const {
-		static_cast<void>(visitor);
+        static_cast<void>(visitor);
     }
 
     COMMON_NODE_FUNCTIONS(NativeCallNode);

--- a/include/mathvm.h
+++ b/include/mathvm.h
@@ -165,7 +165,7 @@ class Status {
       return _msg.c_str();
     }
 
-    const uint32_t getPosition() const {
+    uint32_t getPosition() const {
       return _position;
     }
 


### PR DESCRIPTION
When compiling code with `-Wall -Wextra` flags, several warnings are
emmited for code in header files:
* `-Wunused-parameter` for several virtual method stubs,
* `-Wignored-qualifiers` for 2 methods returning constant ints.

This makes using these flags in solution code really hard.
This commit fixes these warnings:
* Unused parameters in stubs are explicily static casted to `void`.
* Ignored `const` qualifiers are removed.