### PR TITLE
Fixed newton method perf test

### DIFF
--- a/tests/perf/newton.mvm
+++ b/tests/perf/newton.mvm
@@ -9,7 +9,7 @@ function double newton(double xbase) {
   double x = xbase;
   double xp = x - 0.01;
   double y = func(x);
-  double yp = func(yp);
+  double yp = func(xp);
   int repeat = 0;
   while ((fabs(y) > 1e-8) && (repeat < 10000))  {
       double temp = x;


### PR DESCRIPTION
While debugging perf tests, I have found out that in newton test there is usage of an uninitialized variable, that is clearly a bug (not that important for perfomance), and that triggered exception in my intepreter.